### PR TITLE
Switch from scala2-notgiven-compat to scalac-compat-features

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val `redis4cats-transactional-updates` = project.in(file("core"))
         "io.circe" %% "circe-literal" % "0.14.15",
         "org.typelevel" %% "cats-tagless-core" % "0.16.5",
         "org.typelevel" %% "scalac-compat-annotation" % "0.1.4",
-        "com.dwolla" %%% "scala2-notgiven-compat" % "0.1-4ee103a-SNAPSHOT",
+        "org.typelevel" %% "scalac-compat-features" % "0.1.4-145-821ab9f-SNAPSHOT",
       ) ++ Seq(
         "org.typelevel" %% "cats-tagless-macros" % "0.16.5",
       ).filter(_ => scalaVersion.value.startsWith("2"))

--- a/core/src/main/scala-2/com/dwolla/redis/RedisCachePlatform.scala
+++ b/core/src/main/scala-2/com/dwolla/redis/RedisCachePlatform.scala
@@ -5,9 +5,9 @@ import cats.tagless.aop.{Aspect, Instrument}
 import com.dwolla.redis.TraceableValueInstances.*
 import dev.profunktor.redis4cats.effects
 import natchez.TraceableValue
-
-import com.dwolla.compat.scala.util.NotGiven
+import org.typelevel.scalaccompat.scala.util.NotGiven
 import org.typelevel.scalaccompat.annotation.unused
+
 import scala.concurrent.duration.FiniteDuration
 
 private[redis] trait RedisCachePlatform extends RedisCachePlatformLowPriority {

--- a/core/src/main/scala/com/dwolla/redis/TraceableValueInstances.scala
+++ b/core/src/main/scala/com/dwolla/redis/TraceableValueInstances.scala
@@ -6,8 +6,8 @@ import io.circe.*
 import io.circe.literal.*
 import io.circe.syntax.*
 import natchez.*
+import org.typelevel.scalaccompat.scala.util.NotGiven
 
-import com.dwolla.compat.scala.util.NotGiven
 import scala.concurrent.duration.*
 
 private[redis] object TraceableValueInstances {


### PR DESCRIPTION
We're [archiving scala2-notgiven-compat](https://github.com/Dwolla/scala2-notgiven-compat/pull/27) because it was merged into Typelevel's scalac-compat-features. This switches this project over to the new snapshot, which should be updated to the released artifact (once it's available) by Scala Steward.